### PR TITLE
Translation Trait uses language code instead of language names

### DIFF
--- a/library/Centurion/Contrib/translation/traits/Controller/CRUD.php
+++ b/library/Centurion/Contrib/translation/traits/Controller/CRUD.php
@@ -65,9 +65,11 @@ class Translation_Traits_Controller_CRUD extends Translation_Traits_Controller
     public function preDispatch()
     {
         $languageTable = Centurion_Db::getSingleton('translation/language');
+        $languageName = array_flip(Zend_Locale_Data_Translation::$languageTranslation);
+        
         $languagesArray = array();
         foreach ($languageTable->fetchAll() as $lang) {
-            $languagesArray[$lang->pk] = $lang->locale;
+            $languagesArray[$lang->pk] = $languageName[$lang->locale];
         }
 
         try {

--- a/library/Centurion/Contrib/translation/traits/Form/Model.php
+++ b/library/Centurion/Contrib/translation/traits/Form/Model.php
@@ -72,7 +72,7 @@ class Translation_Traits_Form_Model extends Centurion_Traits_Form_Model_Abstract
 
         $this->addElement($this->_generateInfoField(Translation_Traits_Model_DbTable::LANGUAGE_FIELD,
                                                     $this->getView()->translate('Language'),
-                                                    (string) Translation_Traits_Common::getDefaultLanguage()->locale));
+                                                    (string) Translation_Traits_Common::getDefaultLanguage()->name));
 
         
         if ($this->getModel()->isOriginalForcedToDefaultLanguage()) {
@@ -121,7 +121,7 @@ class Translation_Traits_Form_Model extends Centurion_Traits_Form_Model_Abstract
 
             $value = Centurion_Db::getSingleton('translation/language')->get(array('id' => $values[Translation_Traits_Model_DbTable::LANGUAGE_FIELD]));
             $f = $this->_getInfoField(Translation_Traits_Model_DbTable::LANGUAGE_FIELD);
-            $f->setValue((string) $value);
+            $f->setValue((string) $value->name);
 
             $fields = array_merge($spec[Translation_Traits_Model_DbTable::DUPLICATED_FIELDS], $spec[Translation_Traits_Model_DbTable::SET_NULL_FIELDS]);
 

--- a/public/cui/theme/css/grid.css
+++ b/public/cui/theme/css/grid.css
@@ -15,8 +15,7 @@ DATAS GRID */
 .datas tr.hover td {            background-color:#e5ecf9; }
 .datas tr.select td {           background-color:#ffc; }
 
-.datas th {                     margin:0; padding:7px 10px; text-align:left; font-weight:bold;
-                                background:url(../images/cell-separator.png) no-repeat left; }
+.datas th {                     margin:0; padding:7px 10px; text-align:left; font-weight:bold;}
 							
 .datas th a {                   margin:0; padding:0 16px 0 0; text-decoration:none; color:#5b5b5b; position:relative; zoom:1; }
 .datas th a:hover {             text-decoration:none; color:#5b5b5b; }


### PR DESCRIPTION
Language names are used in other other places, such as Translation module.
