### PR TITLE
Add a support of model caching in the Action Helper getObjectOr404

### DIFF
--- a/library/Centurion/Controller/Action/Helper/GetObjectOr404.php
+++ b/library/Centurion/Controller/Action/Helper/GetObjectOr404.php
@@ -39,7 +39,8 @@ class Centurion_Controller_Action_Helper_GetObjectOr404 extends Zend_Controller_
     {
         if (is_string($objectTable)) {
             $objectTable = Centurion_Db::getSingleton($objectTable);
-        } elseif (!$objectTable instanceof Centurion_Db_Table_Abstract) {
+         } elseif (!($objectTable instanceof Centurion_Db_Table_Abstract)
+                    && !($objectTable instanceof Centurion_Db_Cache)) { //To Support getCache() from Centurion Model
             throw new Centurion_Exception('Unknown type of first argument');
         }
         


### PR DESCRIPTION
With the usefull helper "GetObjectOr404", we can pass a model object, but you can not use the cache system provided by the method "getCache" (the test on the type of the object accept only Centurion_Db_Table_Abstract). This commit allows it.
