### PR TITLE
Fix translation adapter

### DIFF
--- a/library/Centurion/Contrib/translation/controllers/helpers/ManageLanguageParam.php
+++ b/library/Centurion/Contrib/translation/controllers/helpers/ManageLanguageParam.php
@@ -34,5 +34,19 @@ class Translation_Controller_Action_Helper_ManageLanguageParam extends Zend_Cont
         if (Centurion_Config_Manager::get('translation.global_param')) {
             $this->getFrontController()->getRouter()->setGlobalParam('language', $requestedLocale);
         }
+
+        //Restore the cache in the adapter (now that the language is found, we can retrieve it ;) )
+        if (Zend_Registry::isRegistered('Zend_Translate')){
+            $translate = Zend_Registry::get('Zend_Translate');
+
+            if ($translate instanceof Translation_Model_Translate_Adapter_Array) {
+                $translate->restoreCache();
+            } else if ($translate instanceof Zend_Translate) {
+                $adapter = $translate->getAdapter();
+                if ($adapter instanceof Translation_Model_Translate_Adapter_Array) {
+                    $adapter->restoreCache();
+                }
+            }
+        }
     }
 }

--- a/library/Centurion/Contrib/translation/models/Translate/Adapter/Array.php
+++ b/library/Centurion/Contrib/translation/models/Translate/Adapter/Array.php
@@ -106,11 +106,12 @@ class Translation_Model_Translate_Adapter_Array extends Zend_Translate_Adapter_A
             $uidId = $this->getUidId($messageId);
             
             $tags = explode(',', $tags);
+            $_tagUidTable = $this->_tagUidTable->getCache();
             foreach ($tags as $tag) {
                 $tag = trim($tag);
                 $tagId = $this->getTagId($tag);
                 
-                $this->_tagUidTable->getOrCreate(array('uid_id' => $uidId, 'tag_id' => $tagId));
+                $_tagUidTable->getOrCreate(array('uid_id' => $uidId, 'tag_id' => $tagId));
             }
         } else {
             $uidId = $this->getUidId($messageId);

--- a/library/Centurion/Contrib/translation/models/Translate/Adapter/Array.php
+++ b/library/Centurion/Contrib/translation/models/Translate/Adapter/Array.php
@@ -18,10 +18,6 @@ class Translation_Model_Translate_Adapter_Array extends Zend_Translate_Adapter_A
         $this->_languageTable = Centurion_Db::getSingleton('translation/language');
         $this->_tagUidTable = Centurion_Db::getSingleton('translation/tagUid');
         parent::__construct($options);
-        
-        if ($cached = self::getCache()->load('Translation_Model_Translate_Adapter_Array_Cache')) {
-            list($this->_checkedWord, $this->_checkedTag, $this->_checkedWordTag) = $cached;
-        }
     }
     
     public function __destruct()
@@ -37,6 +33,25 @@ class Translation_Model_Translate_Adapter_Array extends Zend_Translate_Adapter_A
         	$tags[] = Centurion_Cache_TagManager::getTagOf($this->_languageTable);
         
         self::getCache()->save($cached, 'Translation_Model_Translate_Adapter_Array_Cache', $tags);
+    }
+
+    /**
+     * Restore checkedWord, checkedTag, checkedWordTag from the cache, 
+     * AFTER the language was found by Translation_Controller_Action_Helper_ManageLanguageParam
+     * (originally located in __construct)
+     */
+    public function restoreCache(){
+        if ($cached = self::getCache()->load('Translation_Model_Translate_Adapter_Array_Cache')) {
+            $_checkedWord = array();
+            $_checkedTag = array();
+            $_checkedWordTag = array();                        
+            list($_checkedWord, $_checkedTag, $_checkedWordTag) = $cached;
+            
+      	    //Merge to not lost rows already fetched
+            $this->_checkedWord = array_merge($this->_checkedWord, $_checkedWord);
+            $this->_checkedTag = array_merge($this->_checkedTag, $_checkedTag);
+            $this->_checkedWordTag = array_merge($this->_checkedWordTag, $_checkedWordTag);
+        }
     }
     
     public function getUidId($uid)


### PR DESCRIPTION
Translation_Model_Translate_Adapter_Array can not load the cache identify by "Translation_Model_Translate_Adapter_Array", because : 
- During backup, the id is prefixed by the local. (option "cache_id_prefix" defined Translation_Controller_Action_Helper_ManageLanguageParam).
- But the recovery of the cache is performed before initializing of ManageLanguageParam and the definition of "cache_id_prefix".
- So, the id during backup if "[local]_Translation_Model_Translate_Adapter_Array_Cache" (by example : fr_Translation_Model_Translate_Adapter_Array_Cache) and during recovery "Translation_Model_Translate_Adapter_Array_Cache".

This patch migrate the cache recovery outer of the adapter's constructer in a public method, called by the helper ManageLanguageParam, after he found the local.

So, I a "getCache" on $this->_tagUidTable in the adapter when it checks if a translation uid is linked with a tag.

These patches have halved the number of my queries to my DBMS.
