### PR TITLE
Fix rewrite rules for requests coming from Facebook

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,17 +3,20 @@ RewriteCond %{REQUEST_URI} ^/attachment/.*
 RewriteRule ^attachment/(.*)$ /static/$1 [PT]
 
 RewriteCond %{REQUEST_FILENAME} !-s
-RewriteCond %{QUERY_STRING} ^([^:]*):([^:]*):([^:]*)(:([0-9a-z]*))?(.*)$ [NC]
+RewriteCond %{QUERY_STRING} ^([^:]*):([^:]*):([^:]*)(:([0-9a-z]*))?(.*)$ [NC,OR]
+RewriteCond %{QUERY_STRING} ^([a-zA-Z0-9_-]*)%3A([a-zA-Z0-9_-]*)%3A([a-zA-Z0-9_-]*)(%3A([0-9a-z]*))?%3A(.*)$ [NC]
 RewriteRule ^public/static/(.*)/(.*)$ public/files/%2/_%5.centurion [NC,PT]
 
 #Rewrite for static image (with effect)
 RewriteCond %{REQUEST_FILENAME} !-s
-RewriteCond %{QUERY_STRING} ^([^:]*):([^:]*):([^:]*):([0-9a-z]*)(.*)$ [NC]
+RewriteCond %{QUERY_STRING} ^([^:]*):([^:]*):([^:]*):([0-9a-z]*)(.*)$ [NC,OR]
+RewriteCond %{QUERY_STRING} ^([a-zA-Z0-9_-]*)%3A([a-zA-Z0-9_-]*)%3A([a-zA-Z0-9_-]*)%3A([0-9a-z]*)%3A(.*)$ [NC]
 RewriteRule ^public/files/.*$ public/media/image/get/id/%1/fileid/%2/key/%3/effect/%4/extra/%5? [NC,PT]
 
 #Rewrite for static file
 RewriteCond %{REQUEST_FILENAME} !-s
-RewriteCond %{QUERY_STRING} ^([^:]*):([^:]*):([^:]*)(.*)$ [NC]
+RewriteCond %{QUERY_STRING} ^([^:]*):([^:]*):([^:]*)(.*)$ [NC,OR]
+RewriteCond %{QUERY_STRING} ^([a-zA-Z0-9_-]*)%3A([a-zA-Z0-9_-]*)%3A([0-9a-z]*)%3A(.*)$ [NC]
 RewriteRule ^public/files/.*$ public/media/file/get/id/%1/fileid/%2/key/%3/extra/%4? [NC,PT]
 
 #Rewrite for cached file


### PR DESCRIPTION
Facebook does some weird stuff with colons ":" and we
get these as "%3A". This commit allows images generated
by Centurion to be shared on Facebook
