### PR TITLE
Decorator for elements supporting mutlselect order

### DIFF
--- a/library/Centurion/Contrib/core/forms/Decorator/MultiselectOrder.php
+++ b/library/Centurion/Contrib/core/forms/Decorator/MultiselectOrder.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @class MultiselectOrder_Form_Decorator_MultiselectOrder
+ * Generate a multiselect orderable.
+ * This decorator extends of Zend_Form_Decorator_ViewScript to set the view to use
+ * and add the basePath to find the view resource
+ *
+ * @package Core
+ * @author Richard DELOGE, rd@octaveoctave.com
+ * @copyright Octave & Octave
+ */
+class Core_Form_Decorator_MultiselectOrder extends Zend_Form_Decorator_ViewScript{
+    /**
+     * View script to build the multi select ordered
+     * @var string
+     */
+    protected $_viewScript = 'centurion/form/_element-multiselect.phtml';
+}

--- a/library/Centurion/Contrib/core/forms/Decorator/README.md
+++ b/library/Centurion/Contrib/core/forms/Decorator/README.md
@@ -1,0 +1,19 @@
+To use the multiselect with ordering
+====================================
+
+*   Add a trait on your form to support decorator provided by Core
+
+                class myForm
+                        extends Centurion_Form_Model_Abstract
+                        implements  Core_Traits_Decorators_Form_Model_Interface
+
+
+*   overload the method `render` and add these ligne before call to method `render` of parent :
+        (because Centurion_Form_Model reset elements decorators).
+
+                $this->getElement('myManyToManyRelation')->setDecorators(array(
+                           array('Multiselect' => 'MultiselectOrder')
+                       )
+                   );
+
+

--- a/library/Centurion/Contrib/core/traits/Decorators/Form/Model.php
+++ b/library/Centurion/Contrib/core/traits/Decorators/Form/Model.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @class Core_Traits_Slug_Form_Model
+ * Trait to auto-populate the PluginLoader of Forms
+ * to allow it to load form decorator in Core
+ *
+ * @package Core
+ * @author Richard DELOGE, rd@octaveoctave.com
+ * @copyright Octave & Octave
+ */
+class Core_Traits_Decorators_Form_Model extends Centurion_Traits_Form_Abstract
+{
+    public function __construct($form)
+    {
+        parent::__construct($form);
+        Centurion_Signal::factory('pre_generate')->connect(array($this, 'preGenerate'), $form);
+    }
+
+    /**
+     * Populate pluginLoader to allow it to find Core Decorator
+     */
+    public function preGenerate()
+    {
+        //To use the decorator MultiselectOrder
+        $this->_form->getPluginLoader(Centurion_Form::DECORATOR)->addPrefixPath(
+            'Core_Form_Decorator',
+            APPLICATION_PATH.'/../library/Centurion/Contrib/core/forms/Decorator'
+        );
+    }
+}

--- a/library/Centurion/Contrib/core/traits/Decorators/Form/Model/Interface.php
+++ b/library/Centurion/Contrib/core/traits/Decorators/Form/Model/Interface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @interface Core_Traits_Multiselect_Form_Model_Interface
+ * Trait Interface to auto-populate the PluginLoader of Forms
+ * to allow it to load form decorator in Core
+ *
+ * @package Core
+ * @author Richard DELOGE, rd@octaveoctave.com
+ * @copyright Octave & Octave
+ */
+interface Core_Traits_Decorators_Form_Model_Interface
+{
+
+}

--- a/library/Centurion/Contrib/core/views/scripts/centurion/form/_element-multiselect.phtml
+++ b/library/Centurion/Contrib/core/views/scripts/centurion/form/_element-multiselect.phtml
@@ -1,0 +1,73 @@
+<?php
+    /**
+     * @class
+     * Generate a multiselect orderable.
+     * This decorator extends of Zend_Form_Decorator_ViewScript to set the view to use
+     * and add the basePath to find the view resource
+     *
+     * @package Core
+     * @author Richard DELOGE, rd@octaveoctave.com, Claire Sosset, cs@octaveoctave.com
+     * @copyright Octave & Octave
+     */
+
+    //Extract information from element to build the html element
+    $options = $this->element->getMultiOptions();
+    $name = $this->element->getName();
+    $array_name = $name.'[]';
+    $values = $this->element->getValue();
+?>
+<script type="text/javascript">
+<?php $this->headScript()->captureStart(); ?>
+$(function() {
+    //Add Element
+    $(".field-add-item select").change(function(){
+        var _newValue = $(this).val();
+        if($(this).val() != ''){ /* If the user selected an entry and not the blank element */
+            var _optionSelected = $(this).find('option:selected'); /* extract the select's option selected */
+            $(this).parent().next().append( /* Add a new item in the list */
+                $('<div>', {'class':'field-wrapper field-item-wrapper field-preview-wrapper'})
+                    .append( $('<input>', {'type':'checkbox', 'checked':'checked', 'value':_newValue, 'class':'field-checkbox', 'name':<?php echo json_encode($array_name) ?>} ) )
+                    .append( $('<div>', {'class':'title'}).html( _optionSelected.text() ) )
+            );
+            _optionSelected.remove(); /* remove it to avoid duplicate */
+        }
+    });
+
+    //sortable
+    $(".fieldset.item-order").CUI('sortable', {
+        items: '.field-item-wrapper',
+        placeholder: 'ui-state-highlight'
+    });
+});
+<?php $this->headScript()->captureEnd(); ?>
+</script>
+<div class="form-item">
+    <label for="<?php echo $name ?>"><?php echo $this->element->getLabel() ?></label>
+    <div class="field-wrapper field-add-item">
+        <select>
+            <?php asort($options); //to display non-selected element by alpha?>
+            <?php foreach($options as $key=>$option): ?>
+                <?php if(!in_array($key, $values)): //not add already selected element to prevent duplication ?>
+                    <option value="<?php echo $key;?>"><?php echo $option;?></option>
+                <?php endif; ?>
+            <?php endforeach; ?>
+        </select>
+        <p class="field-description"><?php echo $this->element->getDescription() ?></p>
+    </div>
+    <div class="fieldset item-order">
+    <input type="hidden" name="<?php echo $array_name; ?>" value="" />
+    <?php if(!empty($values)): //Print the list of already selected element. To remove it, use checkbox ?>
+        <?php foreach($values as $key) : ?>
+            <?php
+                $id=$key;
+                $label=$options[$id];
+            ?>
+            <div class="field-wrapper field-item-wrapper field-preview-wrapper">
+                <input type="checkbox" checked="checked" value="<?php echo $id ?>" class="field-checkbox" name="<?php echo $array_name ?>" />
+                <div class="title"><?php echo $label ?></div>
+            </div>
+        <?php endforeach ?>
+    <?php endif ?>
+    </div>
+    <div class="clear"></div>
+</div>

--- a/public/cui/theme/css/form.css
+++ b/public/cui/theme/css/form.css
@@ -313,6 +313,8 @@ form.form .progressBarInProgress,
 form.form .progressBarComplete,
 form.form .progressBarError {   clear:both; }
 .fsUploadProgress 
+.ui-state-highlight,
+.item-order
 .ui-state-highlight {           margin:0 0 5px 175px; _margin-left:86px; position:relative; top:-5px; z-index:1;
                                 zoom:1; background:#ffc; height:58px; width:427px; float:left; }
 .form-main .form-group 


### PR DESCRIPTION
New decorator for multiselect form elements to support ordering.

Centurion provides a mechanism to save the order in relation, and return it in front, but no provide element in form to allow user to order elements. This patch provides a new decorator for multiselect to allow this : 
# To use the multiselect with ordering
-   Add a trait on your form to support decorator provided by Core
  
  ```
          class myForm
                  extends Centurion_Form_Model_Abstract
                  implements  Core_Traits_Decorators_Form_Model_Interface
  ```
-   overload the method `render` and add these lines before calls to method `render` of parent :
      (because Centurion_Form_Model reset elements decorators).
  
  ```
          $this->getElement('myManyToManyRelation')->setDecorators(array(
                     array('Multiselect' => 'MultiselectOrder')
                 )
             );
  ```

@Todo : add a system allows developer to defines new paths in Decorator PluginLoader in the configuration, and remove the trait Core_Traits_Decorators_Form_Model_Interface
