### PR TITLE
fix bug in view error.phtml when the profiler is empty, else spam error_...

### DIFF
--- a/library/Centurion/Contrib/core/views/scripts/centurion/error.phtml
+++ b/library/Centurion/Contrib/core/views/scripts/centurion/error.phtml
@@ -11,6 +11,7 @@
     <?php if (null !== $this->profiler):?>
         LAST QUERY:
         <br />
+        <?php if(!empty($this->profiler)): ?>
         <strong>
             <ul>
                 <?php foreach ($this->profiler as $query):?>
@@ -19,6 +20,7 @@
                 <?php endforeach;?>
             </ul>
         </strong>
+        <?php endif; ?>
     <?php endif;?>
     <br /><br />
 <p><?php echo $this->trace ?></p>


### PR DESCRIPTION
In my php.log, I have several lines generate by error.phtml because the profiler used in core/centurion/form/error.phtml  is empty and the foreach bug.
