### PR TITLE
Fix datepicker form

### DIFF
--- a/library/Centurion/Controller/CRUD.php
+++ b/library/Centurion/Controller/CRUD.php
@@ -205,7 +205,9 @@ class Centurion_Controller_CRUD extends Centurion_Controller_AGL
                 throw new Centurion_Controller_Action_Exception("Empty or invalid property _formClassName");
 
             $this->_form = new $this->_formClassName(array('method' => Centurion_Form::METHOD_POST));
-            $this->_form->setDateFormat($this->_dateFormatIso, $this->_timeFormatIso);
+            if(method_exists($this->_form, 'setDateFormat')){ //For form whom not inherits of Centurion_Form_Model
+                $this->_form->setDateFormat($this->_dateFormatIso, $this->_timeFormatIso);
+            }
             $this->_form->cleanForm();
             $action = $this->_helper->url->url(array_merge($this->_extraParam,
                                                            array('controller' => $this->_request->getControllerName(),

--- a/library/Centurion/Form.php
+++ b/library/Centurion/Form.php
@@ -738,7 +738,7 @@ class Centurion_Form extends Zend_Form implements Centurion_Traits_Traitsable
     public function render(Zend_View_Interface $view = null)
     {
         if (null == $this->getElement('formId'))
-            $this->addELement('hidden', 'formId', array('value' => $this->getFormId()));
+            $this->addElement('hidden', 'formId', array('value' => $this->getFormId()));
         
         if ($this->_clear) {
             $this->renderError();

--- a/library/Centurion/Form/Model/Abstract.php
+++ b/library/Centurion/Form/Model/Abstract.php
@@ -332,10 +332,12 @@ abstract class Centurion_Form_Model_Abstract extends Centurion_Form
 
             foreach ($this->getElements() as $key => $val) {
                 $class = $val->getAttrib('class');
-                if (false !== strpos($class, 'field-datetimepicker')) {
+                if (false !== strpos($class, 'field-datetimepicker') 
+                    && '' != $val->getValue()) { //In the case the field is empty, else Zend_Date is current time
                     $posted_at = new Zend_Date($val->getValue(), 'YYYY-MM-dd HH:mm:ss');
                     $val->setValue($posted_at->get($this->getDateFormat(true)));
-                } else if (false !== strpos($class, 'field-datepicker')) {
+                } else if (false !== strpos($class, 'field-datepicker') 
+                    && '' != $val->getValue()) {
                     $posted_at = new Zend_Date($val->getValue(), 'YYYY-MM-dd HH:mm:ss');
                     $val->setValue($posted_at->get($this->getDateFormat()));
                 }
@@ -890,7 +892,9 @@ abstract class Centurion_Form_Model_Abstract extends Centurion_Form
                         )
                     );
                 } else {
-                    $relatedTable = Centurion_Db::getSingletonByClassName($reference);                    $options = $this->_buildOptions($relatedTable, $columnName, (true === $columnDetails['NULLABLE']));                    $config = array(
+                    $relatedTable = Centurion_Db::getSingletonByClassName($reference);                    
+                    $options = $this->_buildOptions($relatedTable, $columnName, (true === $columnDetails['NULLABLE']));                    
+                    $config = array(
                         'select',
                         array(
                             'multioptions' => $options

--- a/library/Centurion/Form/Model/Abstract.php
+++ b/library/Centurion/Form/Model/Abstract.php
@@ -1033,6 +1033,17 @@ abstract class Centurion_Form_Model_Abstract extends Centurion_Form
     protected function _postGenerate()
     {
         Centurion_Signal::factory('post_generate')->send($this);
+
+        //Add a validator on dates elements to prevent user mistakes
+        foreach ($this->getElements() as $key => $val) {
+            $class = $val->getAttrib('class');
+            if (false !== strpos($class, 'field-datetimepicker')) {
+                $val->addValidator('Date', false, array('format' => $this->getDateFormat(true)));
+
+            } else if (false !== strpos($class, 'field-datepicker')) {
+                $val->addValidator('Date', false, array('format' => $this->getDateFormat()));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Add a Zend date validator on date and datetime fields and fixe somes bugs :
- Fatal error when we use the CRUD with a form inherits of Centurion_Form and not Centurion_Form_Model.
- When a date or datetime field is empty, it was automaticaly populated with the current date.
