### PR TITLE
Fix bug helper navigation isactive

### DIFF
--- a/library/Centurion/Contrib/core/traits/Mptt/Model/DbTable/Row.php
+++ b/library/Centurion/Contrib/core/traits/Mptt/Model/DbTable/Row.php
@@ -456,9 +456,12 @@ class Core_Traits_Mptt_Model_DbTable_Row extends Centurion_Traits_Model_DbTable_
         $this->_row->refresh();
 
         if ($this->_row->getTable()->isRecursiveDelete()) {
-            foreach ($this->getChildren() as $node) {
-                if ($node->id !== $this->id)
-                    $node->delete();
+            $children = $this->getChildren();
+            if(!empty($children)){
+	            foreach ($children as $node) {
+	                if ($node->id !== $this->id)
+	                    $node->delete();
+	            }
             }
         }
 

--- a/library/Centurion/Contrib/core/traits/Slug/Form/Model.php
+++ b/library/Centurion/Contrib/core/traits/Slug/Form/Model.php
@@ -7,9 +7,14 @@ class Core_Traits_Slug_Form_Model extends Centurion_Traits_Form_Abstract
         parent::__construct($form);
         
         Centurion_Signal::factory('pre_generate')->connect(array($this, 'preGenerate'), $form);
+        //To set as no-mandatory the slug fields when it is required in table (field not null)
+        Centurion_Signal::factory('post_generate')->connect(array($this, 'postGenerate'), $form);
         Centurion_Signal::factory('pre_save')->connect(array($this, 'preSave'), $form);
     }
-    
+
+    /**
+     * Add the field slug in the form is the form has the attribute showSlugField set at true
+     */
     public function preGenerate()
     {
         if (isset($this->_form->showSlugField)) {
@@ -18,7 +23,18 @@ class Core_Traits_Slug_Form_Model extends Centurion_Traits_Form_Abstract
             $this->_elementLabels = $elementLabels;
         }
     }
-    
+
+    /**
+     * Called to set the field slug as no-mandatory
+     */
+    public function postGenerate(){
+        if (isset($this->_form->showSlugField)) {
+            //It is automaticaly generated if it is not exist...
+            if($slug = $this->_form->getElement('slug'))
+                $slug->setRequired(false);
+        }
+    }
+
     public function preSave()
     {
         $this->_form->enableElement('slug');

--- a/library/Centurion/Contrib/media/forms/Decorator/MultiFile.php
+++ b/library/Centurion/Contrib/media/forms/Decorator/MultiFile.php
@@ -80,6 +80,7 @@ EOS
         $content = <<<EOS
         <div class="form-item">
             <label for="$name">$label</label>
+            <input type="hidden" name="${inputName}[]" id="${inputName}-empty" value=""/>
             <div class="field-wrapper field-upload-wrapper">
                 <div class="float-right">
                     <span id="divStatus">0 files uploaded</span> &nbsp;

--- a/library/Centurion/View/Helper/Navigation/Menu.php
+++ b/library/Centurion/View/Helper/Navigation/Menu.php
@@ -167,7 +167,7 @@ class Centurion_View_Helper_Navigation_Menu extends Zend_View_Helper_Navigation_
             }
 
             // render li tag and page
-            $liClass = $page->isActive() ? ' class="active"' : '';
+            $liClass = $page->isActive(true) ? ' class="active"' : '';
             $html .= $myIndent . '    <li' . $liClass . '>' . self::EOL
                    . $myIndent . '        ' . $this->htmlify($page) . self::EOL;
 


### PR DESCRIPTION
Because the navigation helper did check only if the parent in menu tree is active, and not its children.
