### PR TITLE
[centurion] don't urlencode twice for navigation

### DIFF
--- a/library/Centurion/Contrib/admin/controllers/AdminNavigationController.php
+++ b/library/Centurion/Contrib/admin/controllers/AdminNavigationController.php
@@ -94,7 +94,7 @@ class Admin_AdminNavigationController extends Centurion_Controller_Mptt implemen
             foreach ($types as $type) {
                 if (isset($type['className']) && $row->proxy->getTable() instanceof $type['className']) {
                     if (isset($type['urlEdit'])) {
-                        $type['urlEdit']['_next'] = urlencode($this->view->url(array('action' => 'index')));
+                        $type['urlEdit']['_next'] = $this->view->url(array('action' => 'index'));
                         $type['urlEdit']['id'] = $row->proxy->id;
                         $this->_redirect($this->view->url($type['urlEdit']));
                         die();

--- a/library/Centurion/Contrib/admin/views/scripts/admin-navigation/index.phtml
+++ b/library/Centurion/Contrib/admin/views/scripts/admin-navigation/index.phtml
@@ -27,7 +27,7 @@ $urls = array();
         foreach ($this->types as $type => $config):
 
            $extraParam = array();
-           $extraParam['_next'] = urlencode($this->url(array('action' => 'add-proxy', 'proxy_pk' => '___pk___', 'proxy_model' => '___model___')));
+           $extraParam['_next'] = $this->url(array('action' => 'add-proxy', 'proxy_pk' => '___pk___', 'proxy_model' => '___model___'));
            $url = $this->url(array_merge($config['urlNew'], $extraParam));
            $urls[] = '\'' . $type .'\' : "' . addslashes($url) . '"';
         endforeach;


### PR DESCRIPTION
This caused the redirection to the navigation page to fail after editing a flatpage.
