### PR TITLE
[centurion] make hydrate not populate empty rows. Don't fetch null rows ...

### DIFF
--- a/library/Centurion/Db/Table/Row/Abstract.php
+++ b/library/Centurion/Db/Table/Row/Abstract.php
@@ -611,7 +611,7 @@ abstract class Centurion_Db_Table_Row_Abstract extends Zend_Db_Table_Row_Abstrac
 
                 $exist = true;
                 foreach($table->info('primary') as $pkfield) {
-                    if(empty($rawData[$pkfield])) {
+                    if(empty($rowData['data'][$pkfield])) {
                         $exist = false;
                         break;
                     }

--- a/library/Centurion/Db/Table/Row/Abstract.php
+++ b/library/Centurion/Db/Table/Row/Abstract.php
@@ -200,7 +200,14 @@ abstract class Centurion_Db_Table_Row_Abstract extends Zend_Db_Table_Row_Abstrac
 
                 self::$_relationship[$className][$pkValue]
                     = $this->findParentRow($referenceMap[$columnName]['refTableClass'],
-                    $columnName);
+                                           $columnName);
+                if (null === self::$_relationship[$className][$pkValue]) { 
+                    self::$_relationship[$className][$pkValue] = false; 
+                }
+            }
+            
+            if (false == self::$_relationship[$className][$pkValue]) {
+                return null;
             }
             return self::$_relationship[$className][$pkValue];
         }
@@ -501,8 +508,14 @@ abstract class Centurion_Db_Table_Row_Abstract extends Zend_Db_Table_Row_Abstrac
                 if (!isset(self::$_relationship[$className][$this->{$column}])) {
                     self::$_relationship[$className][$this->{$column}]
                         = $this->findParentRow($referenceMap[$columnName]['refTableClass'], $columnName, $select);
+                    if (null === self::$_relationship[$className][$this->{$column}]) { 
+                        self::$_relationship[$className][$this->{$column}] = false; 
+                    }
                 }
-
+            
+                if (false == self::$_relationship[$className][$this->{$column}]) {
+                    return null;
+                }
                 return self::$_relationship[$className][$this->{$column}];
             }
             $dependentTables = $this->getTable()->info('dependentTables');
@@ -596,7 +609,20 @@ abstract class Centurion_Db_Table_Row_Abstract extends Zend_Db_Table_Row_Abstrac
 
                 $rowClassName = $table->getRowClass();
 
-                self::$_relationship[$className][$this->{$column}] = new $rowClassName($rowData);
+                $exist = true;
+                foreach($table->info('primary') as $pkfield) {
+                    if(empty($rawData[$pkfield])) {
+                        $exist = false;
+                        break;
+                    }
+                }
+                if(!$exist) {
+                    self::$_relationship[$className][$this->{$column}] = false;
+                }
+                else {
+                    self::$_relationship[$className][$this->{$column}] = new $rowClassName($rowData);
+                }
+                
             }
         }
     }


### PR DESCRIPTION
...multiple times

Conflicts:

```
library/Centurion/Db/Table/Row/Abstract.php
```

Conflicts were differences between version of Centurion using a $pkValue variable (the current one) and older version using $this->{$column}
