### PR TITLE
Add test for isset on rows. Fix isset for specialGets

### DIFF
--- a/library/Centurion/Db/Table/Row/Abstract.php
+++ b/library/Centurion/Db/Table/Row/Abstract.php
@@ -385,8 +385,12 @@ abstract class Centurion_Db_Table_Row_Abstract extends Zend_Db_Table_Row_Abstrac
 
         //Test special get column
         if (array_key_exists($columnName, $this->_specialGets)) {
-            if (!method_exists($this, $this->_specialGets[$columnName])) {
-                throw new Centurion_Db_Table_Exception(sprintf("Specified method \"%s\" does not exist", $this->_specialGets[$columnName]));
+            $callbackValue = $this->_specialGets[$columnName];
+            if(is_string($callbackValue)) {
+                $callbackValue = array($this, $callbackValue);
+            }
+            if(!is_callable($callbackValue)) {
+                throw new Centurion_Db_Table_Exception(sprintf("Specified callback uncallable for %s", $columnName));
             }
             return true;
         }

--- a/tests/library/Centurion/Db/Table/RowTest.php
+++ b/tests/library/Centurion/Db/Table/RowTest.php
@@ -215,6 +215,44 @@ class Centurion_Db_Table_RowTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Centurion_Db_Table_Row_Abstract::__isset
+     */
+    public function testFunction__Isset()
+    {
+        $table = new Asset_Model_DbTable_Simple();
+        $row = $table->createRow();
+        $row->save();
+        $row->title = 'title';
+
+        // this column exists
+        $this->assertTrue(isset($row->title), 'calling isset on a set column returned false');
+
+        // this column doesn't exist
+        $this->assertFalse(isset($row->unexistent), 'calling isset on an unset column returned true');
+
+        $tableWithRef = new Asset_Model_DbTable_WithRef();
+        $withRef = $tableWithRef->createRow();
+        $withRef->simple_id = $row->id;
+        $withRef->save();
+
+        // this column is a referenceMap
+        $this->assertTrue(isset($withRef->simple), 'calling isset on a reference returned false');
+
+        // this column is a reference field
+        $this->assertTrue(isset($withRef->simple__title), 'calling isset on a reference\'s field returned false');
+
+        $tableSpecialGet = new Asset_Model_DbTable_WithSpecialGet();
+        $withSpecialGet = $tableSpecialGet->createRow();
+        $withSpecialGet->save();
+
+        // this column is a special get with a methodName as string
+        $this->assertTrue(isset($withSpecialGet->method), 'Calling isset on a specialget by string returned false');
+
+        // this column is a special get with a callable array as parameter
+        $this->assertTrue(isset($withSpecialGet->arrayGet), 'Calling isset on a specialget by callable array returned false');
+    }
+
+    /**
      * @covers Centurion_Db_Table_Row_Abstract::getModifiedData
      * @covers Centurion_Db_Table_Row_Abstract::reset
      */

--- a/tests/support/Asset/Model/DbTable/Row/SimpleWithSpecialGet.php
+++ b/tests/support/Asset/Model/DbTable/Row/SimpleWithSpecialGet.php
@@ -1,0 +1,16 @@
+<?php
+
+class Asset_Model_DbTable_Row_SimpleWithSpecialGet extends Centurion_Db_Table_Row
+{
+    
+    public function __construct(array $config) {
+        $this->_specialGets['method'] = 'specialGetMethod';
+        $this->_specialGets['arrayGet'] = array($this, 'specialGetMethod');
+        parent::__construct($config);
+    }
+    public function specialGetMethod()
+    {
+        return 'success';
+    }
+}
+

--- a/tests/support/Asset/Model/DbTable/SimpleWithSlug.php
+++ b/tests/support/Asset/Model/DbTable/SimpleWithSlug.php
@@ -22,6 +22,5 @@ EOS
     protected function _destructTable()
     {
         $this->getDefaultAdapter()->query('Drop table test_simple_with_slug');
-        echo 'ici';
     }
 }

--- a/tests/support/Asset/Model/DbTable/WithSpecialGet.php
+++ b/tests/support/Asset/Model/DbTable/WithSpecialGet.php
@@ -1,0 +1,32 @@
+<?php
+
+class Asset_Model_DbTable_WithSpecialGet extends Asset_Model_DbTable_Abstract
+{
+    protected $_name = 'test_with_special_get';
+
+    protected $_rowClass = 'Asset_Model_DbTable_Row_SimpleWithSpecialGet';
+
+
+    protected function _createTable()
+    {
+        $this->getDefaultAdapter()->query(<<<EOS
+            CREATE TABLE IF NOT EXISTS test_with_special_get (
+            `id` INT( 11 ) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY ,
+            `title` VARCHAR( 255 ) NOT NULL
+            ) ENGINE = INNODB;
+EOS
+        );
+    }
+
+    protected function _destructTable()
+    {
+        $this->getDefaultAdapter()->query('Drop table test_with_special_get');
+    }
+
+    public function __construct($config = array())
+    {
+        parent::__construct($config);
+    }
+
+}
+


### PR DESCRIPTION
I had to make a change for isset on specialGets which did not check for callback arrays.
noticing this part was not tested yet, i took the liberty of writing a test for it.
