### PR TITLE
Update library/Centurion/Contrib/core/views/helpers/Navigation.php

### DIFF
--- a/library/Centurion/Contrib/core/views/helpers/Navigation.php
+++ b/library/Centurion/Contrib/core/views/helpers/Navigation.php
@@ -53,6 +53,15 @@ class Centurion_View_Helper_Navigation extends Zend_View_Helper_Navigation
             return $this->_helpers[$proxy];
         }
 
+        //To keep compliance with normal behavior of Zend_View_Helper_Navigation
+        //(Because, the namespace of the Zend Navigation was not registered into the plugin loader)
+        if (!$this->view->getPluginLoader('helper')->getPaths(Zend_View_Helper_Navigation::NS)) {
+            $this->view->addHelperPath(
+                str_replace('_', '/', Zend_View_Helper_Navigation::NS),
+                Zend_View_Helper_Navigation::NS);
+        }
+        //End support for the normal behavior
+
         if (!$this->view->getPluginLoader('helper')->getPaths(self::NS)) {
             $this->view->addHelperPath(
                     str_replace('_', '/', self::NS),


### PR DESCRIPTION
In the helper "Centurion_View_Helper_Navigation" (inherits from Zend_View_Helper_Navigation) to use Centurion Navigations Helpers instead of Zend Navigations Helpers : zend helpers was also not registered in the plugin loader, so Developpers can not use Zend Navigation Helpers (like Sitemap).

This patch records Zend Helpers before Centurion Helpers to use them when we have found nothing in Centurion.
