### PR TITLE
move line 

### DIFF
--- a/library/Centurion/Controller/CRUD.php
+++ b/library/Centurion/Controller/CRUD.php
@@ -411,10 +411,12 @@ class Centurion_Controller_CRUD extends Centurion_Controller_AGL
     protected function _renderForm($form)
     {
         $this->view->form = $form;
-        $this->view->formViewScript = 'grid/_form.phtml';
 
         $this->_preRenderForm();
 
+        $this->view->formViewScript = 'grid/_form.phtml';
+        
+        
         $script = substr($this->view->selectScript(array($this->_formViewScript, 'grid/form.phtml')), 0, -6);
         //$script = substr($this->view->selectScript(array(sprintf('%s/form.phtml', $this->_request->getControllerName()), 'grid/form.phtml')), 0, -6);
         $this->render($script, true, true);


### PR DESCRIPTION
Grid/_form must be at the end of the table because it must be used if no view has been added previously in table
