### PR TITLE
New condition for sort check

### DIFF
--- a/library/Centurion/Controller/AGL.php
+++ b/library/Centurion/Controller/AGL.php
@@ -534,7 +534,7 @@ class Centurion_Controller_AGL extends Centurion_Controller_Action
             $useDefaultSort = true;
 
             if (null !== $this->_sort && isset($this->_displays[$this->_sort])) {
-                if (!isset($this->_displays[$this->_sort]['sortable']) || $this->_displays[$this->_sort]['sortable'] == false) {
+                if (!is_array($this->_displays[$this->_sort]) || !isset($this->_displays[$this->_sort]['sortable']) || $this->_displays[$this->_sort]['sortable'] == false) {
                     $useDefaultSort = false;
                 }
             }


### PR DESCRIPTION
If the _display['col'] was not an array it could'nt sort on et
