### PR TITLE
Update library/Centurion/Contrib/admin/forms/Filter.php

### DIFF
--- a/library/Centurion/Contrib/admin/forms/Filter.php
+++ b/library/Centurion/Contrib/admin/forms/Filter.php
@@ -228,7 +228,7 @@ class Admin_Form_Filter extends Centurion_Form
                 case Centurion_Controller_CRUD::FILTER_BEHAVIOR_CONTAINS:
                     $tabs = explode(' ', $value);
                     foreach ($tabs as $value) {
-                        $sqlFilter[] = array($this->_filters[$key]['column'] . Centurion_Db_Table_Select::RULES_SEPARATOR . Centurion_Db_Table_Select::OPERATOR_CONTAINS, '%' . $value . '%');
+                        $sqlFilter[$this->_filters[$key]['column'] . Centurion_Db_Table_Select::RULES_SEPARATOR . Centurion_Db_Table_Select::OPERATOR_CONTAINS][] = '%' . $value . '%';
                     }
                     break;
                 case Centurion_Controller_CRUD::FILTER_BEHAVIOR_IN:


### PR DESCRIPTION
Actually the filter functionnality doesn't work correctly on a Centurion_Controller_CRUD (Centurion_Controller AGL too i supose).
The problem appears when Centurion uses FILTER_BEHAVIOR_CONTAINS. I've the error below:
Exception Zend_Db_Statement_Exception SQLSTATE[42S22]: Column not found: 1054 Unknown column 'Array' in 'where clause' sent in C:\wamp\www\changeshape.new\library\Zend\Db\Statement\Pdo.php at line 61 
So i've make some change on this file and for now it's seems to work.
For your intention, I've notice another problem too when centurion uses FILTER_BEHAVIOR_IN. I've the error message below :
Exception Zend_Db_Statement_Exception SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'IN ('2'))' at line 1 sent in C:\wamp\www\changeshape.new\library\Zend\Db\Statement\Pdo.php at line 61 
The select query seems to looks like this:
SELECT `fitness_workout`.\* FROM `fitness_workout` WHERE (.`difficulty_id` IN ('1'))
Centurion seems not to able to find the tablename.

For now i ve only propose one change for FILTER_BEHAVIOR_CONTAINS bug.
