### PR TITLE
Update library/Centurion/Db/Table/Select.php

### DIFF
--- a/library/Centurion/Db/Table/Select.php
+++ b/library/Centurion/Db/Table/Select.php
@@ -690,6 +690,7 @@ class Centurion_Db_Table_Select extends Zend_Db_Table_Select implements Countabl
                     $foreignTable = Centurion_Db::getSingletonByClassName($dependentRefMap[$rule[1]]['refTableClass']);
                     $uniqName = $this->addDependentTable($rule[1], $localTable, array(), $rule[0]);
                 } else {
+                    $uniqName = $this->_adapter->quoteIdentifier($this->getTable()->info('name'));
                     $sqlField = sprintf('%s.%s', $uniqName,
                                                  $this->_adapter->quoteIdentifier($dependentRefMap[$rule[1]]['columns']));
                 }


### PR DESCRIPTION
I've make some change on this file cause centurion was not able to retrieve the tablename when use FILTER_BEHAVIOR_IN on filter functionnality.
As we see, before $uniqName is not assigned so i've assigned the tablename to $uniqName variable
